### PR TITLE
Fix UUID helper

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,10 +1,10 @@
-import uuid from 'react-native-uuid';
+import UUID from 'react-native-uuid';
 
 /**
  * Generate a RFC4122 UUID string (uses 'react-native-uuid' for cross-platform support)
  */
 export const generateUUID = () => {
-  return uuid.v4();
+  return (UUID.v4 || UUID.default?.v4)();
 };
 
 export default { generateUUID };


### PR DESCRIPTION
## Summary
- update `generateUUID` to work with CJS or ESM builds of `react-native-uuid`
- keep existing callers unchanged

## Testing
- `npm install`
- `node --test __tests__/utils/helpers.test.mjs`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_6854333a7a8c832f8d82a8d16fd40eec