### PR TITLE
Add test script to package.json and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # GroceryBud
+
+## Running tests
+
+This project uses Node's built-in test runner. To execute the test suite, run:
+
+```bash
+npm test
+```
+
+All test files live in the `__tests__` directory.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "node --test"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",


### PR DESCRIPTION
## Summary
- add `test` script to `package.json`
- document how to run the test suite in `README.md`

## Testing
- `npm test` *(fails: cannot find package `react-native-uuid`)*

------
https://chatgpt.com/codex/tasks/task_e_6854333d4f54832fab3ad14f98ccbadf