### PR TITLE
Add password reset mocks and tests

### DIFF
--- a/__tests__/services/authActions.test.mjs
+++ b/__tests__/services/authActions.test.mjs
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import AsyncStorage from '../../src/services/storage/AsyncStorage.js';
+import { forgotPasswordRequest, resetPasswordRequest } from '../../src/context/authMockService.js';
+
+const USERS_KEY = 'MOCK_USERS_DB';
+const tokenKey = (email) => `RESET_TOKEN_${email}`;
+
+test('forgotPasswordRequest stores a reset token', async () => {
+  await AsyncStorage.clear();
+  const user = { uid: '1', email: 'test@example.com', password: '123' };
+  await AsyncStorage.setItem(USERS_KEY, JSON.stringify([user]));
+
+  const result = await forgotPasswordRequest('test@example.com');
+  assert.equal(result.success, true);
+  const stored = await AsyncStorage.getItem(tokenKey('test@example.com'));
+  assert.ok(stored);
+});
+
+test('resetPasswordRequest changes password and clears token', async () => {
+  await AsyncStorage.clear();
+  const user = { uid: '1', email: 'test@example.com', password: 'old' };
+  await AsyncStorage.setItem(USERS_KEY, JSON.stringify([user]));
+  await AsyncStorage.setItem(tokenKey('test@example.com'), 'token');
+
+  const res = await resetPasswordRequest('test@example.com', 'newpass');
+  assert.equal(res.success, true);
+
+  const users = JSON.parse(await AsyncStorage.getItem(USERS_KEY));
+  assert.equal(users[0].password, 'newpass');
+  const token = await AsyncStorage.getItem(tokenKey('test@example.com'));
+  assert.equal(token, null);
+});

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import React, { createContext, useContext, useEffect, useReducer } from 'react';
 import { STORAGE_KEYS } from '../utils/constants';
 import { generateUUID } from '../utils/helpers';
+import { forgotPasswordRequest, resetPasswordRequest } from './authMockService';
 
 // Initial state
 const initialState = {
@@ -134,6 +135,8 @@ const getCurrentUser = async () => {
   return { success: false, user: null };
 };
 
+// Mock forgotPassword
+
 // --- Auth Context ---
 
 const AuthContext = createContext();
@@ -186,6 +189,28 @@ export const AuthProvider = ({ children }) => {
       const result = await signOutUser();
       if (result.success) {
         dispatch({ type: ActionTypes.SIGN_OUT });
+      }
+      dispatch({ type: ActionTypes.SET_LOADING, payload: false });
+      return result;
+    },
+    forgotPassword: async (email) => {
+      dispatch({ type: ActionTypes.SET_LOADING, payload: true });
+      const result = await forgotPasswordRequest(email);
+      if (!result.success) {
+        dispatch({ type: ActionTypes.SET_ERROR, payload: result.message });
+      } else {
+        dispatch({ type: ActionTypes.CLEAR_ERROR });
+      }
+      dispatch({ type: ActionTypes.SET_LOADING, payload: false });
+      return result;
+    },
+    resetPassword: async (email, password) => {
+      dispatch({ type: ActionTypes.SET_LOADING, payload: true });
+      const result = await resetPasswordRequest(email, password);
+      if (!result.success) {
+        dispatch({ type: ActionTypes.SET_ERROR, payload: result.message });
+      } else {
+        dispatch({ type: ActionTypes.CLEAR_ERROR });
       }
       dispatch({ type: ActionTypes.SET_LOADING, payload: false });
       return result;

--- a/src/context/authMockService.js
+++ b/src/context/authMockService.js
@@ -1,0 +1,39 @@
+import AsyncStorage from '../services/storage/AsyncStorage.js';
+import { generateUUID } from '../utils/helpers.js';
+
+const USERS_KEY = 'MOCK_USERS_DB';
+
+export const getMockUsers = async () => {
+  const users = await AsyncStorage.getItem(USERS_KEY);
+  return users ? JSON.parse(users) : [];
+};
+
+export const forgotPasswordRequest = async (email) => {
+  const users = await getMockUsers();
+  const user = users.find(u => u.email === email);
+  if (!user) {
+    return { success: false, message: 'No account found with that email.' };
+  }
+  const token = generateUUID();
+  await AsyncStorage.setItem(`RESET_TOKEN_${email}`, token);
+  return { success: true, message: 'Password reset email sent.', token };
+};
+
+export const resetPasswordRequest = async (email, newPassword) => {
+  const tokenKey = `RESET_TOKEN_${email}`;
+  const storedToken = await AsyncStorage.getItem(tokenKey);
+  if (!storedToken) {
+    return { success: false, message: 'Invalid or expired reset request.' };
+  }
+  const users = await getMockUsers();
+  const index = users.findIndex(u => u.email === email);
+  if (index === -1) {
+    return { success: false, message: 'No account found with that email.' };
+  }
+  users[index].password = newPassword;
+  await AsyncStorage.setItem(USERS_KEY, JSON.stringify(users));
+  await AsyncStorage.removeItem(tokenKey);
+  return { success: true, message: 'Password has been reset.' };
+};
+
+export default { getMockUsers, forgotPasswordRequest, resetPasswordRequest };

--- a/src/screens/auth/ForgotPasswordScreen.js
+++ b/src/screens/auth/ForgotPasswordScreen.js
@@ -19,7 +19,7 @@ const ForgotPasswordScreen = ({ navigation }) => {
   const [emailSent, setEmailSent] = useState(false);
   const [resetError, setResetError] = useState(null);
   
-  const { resetPassword } = useAuth();
+  const { forgotPassword } = useAuth();
   const theme = useTheme();
   const styles = getStyles(theme);
 
@@ -43,7 +43,7 @@ const ForgotPasswordScreen = ({ navigation }) => {
     setResetError(null);
 
     try {
-      const result = await resetPassword(email);
+      const result = await forgotPassword(email);
       
       if (result.success) {
         setEmailSent(true);

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -4,7 +4,8 @@ import uuid from 'react-native-uuid';
  * Generate a RFC4122 UUID string (uses 'react-native-uuid' for cross-platform support)
  */
 export const generateUUID = () => {
-  return uuid.v4();
+  const generator = uuid.v4 || (uuid.default && uuid.default.v4);
+  return generator();
 };
 
 export default { generateUUID };


### PR DESCRIPTION
## Summary
- add mock service for password reset logic
- use the mock password reset actions in AuthContext
- update ForgotPasswordScreen to call forgotPassword
- update helper UUID generation for Node ESM
- add unit tests for password reset actions

## Testing
- `npm install`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_6854333bcee8832f8c137ad1ee60ca8d