### PR TITLE
Ensure fonts remain defined in ThemeContext

### DIFF
--- a/__tests__/context/ThemeContext.test.mjs
+++ b/__tests__/context/ThemeContext.test.mjs
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import register from '@babel/register';
+register({ presets: ['babel-preset-expo'], extensions: ['.js', '.jsx'] });
+
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { ThemeProvider, useTheme } from '../../src/context/ThemeContext.js';
+
+function Capture() {
+  global.__theme = useTheme();
+  return null;
+}
+
+test('fonts remain defined after initialization and updateTheme', async () => {
+  await act(async () => {
+    TestRenderer.create(
+      <ThemeProvider>
+        <Capture />
+      </ThemeProvider>
+    );
+    await Promise.resolve();
+  });
+
+  assert.ok(global.__theme.fonts.regular);
+  assert.ok(global.__theme.fonts.medium);
+  assert.ok(global.__theme.fonts.bold);
+
+  await act(async () => {
+    global.__theme.updateTheme({ colors: { test: '#000' } });
+    await Promise.resolve();
+  });
+
+  assert.ok(global.__theme.fonts.regular);
+  assert.ok(global.__theme.fonts.medium);
+  assert.ok(global.__theme.fonts.bold);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "react-native-web": "^0.20.0"
       },
       "devDependencies": {
-        "@babel/core": "^7.20.0"
+        "@babel/core": "^7.20.0",
+        "react-test-renderer": "^19.0.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -7042,6 +7043,27 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.0.0.tgz",
+      "integrity": "sha512-oX5u9rOQlHzqrE/64CNr0HB0uWxkCQmZNSfozlYvwE71TLVgeZxVf0IjouGEr1v7r1kcDifdAJBeOhdhxsG/DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^19.0.0",
+        "scheduler": "^0.25.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
+      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/regenerate": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-native-web": "^0.20.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0"
+    "@babel/core": "^7.20.0",
+    "react-test-renderer": "^19.0.0"
   },
   "private": true
 }

--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -15,7 +15,15 @@ export const THEME_MODES = {
 // Initial state
 const initialState = {
   mode: THEME_MODES.AUTO,
-  theme: lightTheme,
+  theme: {
+    ...lightTheme,
+    typography,
+    fonts: {
+      regular: typography.body1.fontFamily || 'System',
+      medium: typography.label.fontFamily || 'System',
+      bold: typography.h1.fontFamily || 'System',
+    },
+  },
   isDark: false,
   systemTheme: Appearance.getColorScheme() || 'light',
 };
@@ -41,10 +49,14 @@ const themeReducer = (state, action) => {
         ...state,
         mode,
         isDark,
-        theme: { 
-          ...newTheme, 
-          typography, 
-          fonts: { regular: typography.body1 } 
+        theme: {
+          ...newTheme,
+          typography,
+          fonts: {
+            regular: typography.body1.fontFamily || 'System',
+            medium: typography.label.fontFamily || 'System',
+            bold: typography.h1.fontFamily || 'System',
+          },
         },
       };
     }
@@ -60,10 +72,14 @@ const themeReducer = (state, action) => {
         ...state,
         systemTheme,
         isDark,
-        theme: { 
-          ...newTheme, 
-          typography, 
-          fonts: { regular: typography.body1 } 
+        theme: {
+          ...newTheme,
+          typography,
+          fonts: {
+            regular: typography.body1.fontFamily || 'System',
+            medium: typography.label.fontFamily || 'System',
+            bold: typography.h1.fontFamily || 'System',
+          },
         },
       };
     }
@@ -72,8 +88,12 @@ const themeReducer = (state, action) => {
       const updatedTheme = {
         ...state.theme,
         ...action.payload,
+        fonts: {
+          ...state.theme.fonts,
+          ...(action.payload.fonts || {}),
+        },
       };
-      
+
       return {
         ...state,
         theme: updatedTheme,


### PR DESCRIPTION
## Summary
- extend initial theme with `typography` and `fonts`
- build fonts object when switching theme mode or system theme
- keep fonts when updating theme
- add unit test verifying fonts are always available
- install `react-test-renderer` for tests

## Testing
- `npm test` *(fails: Cannot find package '@babel/register', uuid not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68543e5aba40832f96bb97d4d0e4f8f1